### PR TITLE
Fix: Automatically scroll to top on page navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_MARKET_ID } from "./constants/applications";
 import Portfolio from "./pages/Portfolio";
 import { AppContainer } from "./app-styles";
 import SDKProvider from "./providers/SDKProvider";
+import ScrollToTop from './utils/scrollToTop'
 
 const App = () => {
   const chainIdRef = useRef<number | undefined>(undefined);
@@ -25,6 +26,7 @@ const App = () => {
       <SDKProvider>
         <Theme>
           <AppContainer>
+            <ScrollToTop />
             <Popups />
             <Flex direction={{ initial: "column", sm: "row" }} width={"100%"}>
               <NavBar />

--- a/src/utils/scrollToTop.ts
+++ b/src/utils/scrollToTop.ts
@@ -1,0 +1,12 @@
+import {useEffect} from 'react'
+import {useLocation} from 'react-router-dom'
+
+export default function ScrollToTop() {
+  const {pathname} = useLocation()
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  return null
+}


### PR DESCRIPTION
## Description
This PR addresses the issue where the page maintains its scroll position when navigating between routes, causing new pages to open in a scrolled state instead of at the top.

## Changes
- Added a new `ScrollToTop` component that utilizes React Router's `useLocation` hook to detect route changes
- Implemented the `ScrollToTop` component in the main `App` component to ensure it's active across all route changes

## Additional Notes
- This solution uses the `window.scrollTo(0, 0)` method, which should work for most cases. If we encounter issues with specific pages or components, we may need to implement a more nuanced approach.