### PR TITLE
feat(trade): set default leverage to 5

### DIFF
--- a/src/state/trade/reducer.ts
+++ b/src/state/trade/reducer.ts
@@ -20,7 +20,7 @@ export interface TradeState {
 
 export const initialState: TradeState = {
   typedValue: "",
-  selectedLeverage: "1",
+  selectedLeverage: "5",
   isLong: true,
   slippageValue: "1",
   txnHash: '',


### PR DESCRIPTION
## Summary
- default leverage 5x on trade page widget

## Testing
- `pnpm lint` *(fails: Unnecessary semicolon and other lint errors in existing files)*
- `npx eslint src/state/trade/reducer.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b9cc299f70832e978354cc5a095fac