### PR TITLE
feat: add serverless trade meta rendering

### DIFF
--- a/api/trade.ts
+++ b/api/trade.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { getMarketMeta } from '../src/utils/getMarketMeta';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+function readTemplate() {
+  const distPath = path.join(process.cwd(), 'dist', 'index.html');
+  const srcPath = path.join(process.cwd(), 'index.html');
+  const templatePath = fs.existsSync(distPath) ? distPath : srcPath;
+  return fs.readFileSync(templatePath, 'utf8');
+}
+
+export default function handler(
+  req: IncomingMessage & { query?: Record<string, unknown> },
+  res: ServerResponse
+) {
+  const query = (req as any).query || {};
+  const market = typeof query.market === 'string' ? (query.market as string) : undefined;
+  const { title, description, image } = getMarketMeta(market);
+
+  const headTags = `\n    <meta property="og:title" content="${title}" />\n    <meta property="og:image" content="${image}" />\n    <meta name="description" content="${description}" />\n    <meta property="og:description" content="${description}" />\n  `;
+
+  const template = readTemplate();
+  const html = template.replace('</head>', `${headTags}</head>`);
+
+  res.setHeader('Content-Type', 'text/html');
+  res.statusCode = 200;
+  (res as any).send ? (res as any).send(html) : res.end(html);
+}

--- a/src/utils/getMarketMeta.ts
+++ b/src/utils/getMarketMeta.ts
@@ -1,0 +1,15 @@
+import { DEFAULT_LOGO, MARKETS_FULL_LOGOS } from "../constants/markets";
+
+export interface MarketMeta {
+  title: string;
+  description: string;
+  image: string;
+}
+
+export function getMarketMeta(encodedMarket?: string): MarketMeta {
+  const marketKey = encodedMarket ?? "";
+  const title = marketKey ? decodeURIComponent(marketKey) : "Overlay Markets";
+  const image = MARKETS_FULL_LOGOS[marketKey] ?? DEFAULT_LOGO;
+  const description = `Trade ${title} on Overlay Markets`;
+  return { title, description, image };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src", "custom-types.d.ts"],
+  "include": ["src", "custom-types.d.ts", "api"],
   "exclude": ["src/charting_library"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    { "source": "/trade", "destination": "/api/trade" }
+  ],
+  "botProtection": {
+    "allowlist": ["Twitterbot"]
+  }
+}


### PR DESCRIPTION
## Summary
- add serverless function to inject OG meta tags per trade market
- generate market meta (title, description, image) during rendering
- configure Vercel bot protection to allow Twitterbot

## Testing
- `pnpm lint` *(fails: Unexpected any, no-extra-semi, etc.)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bae0198988832e9251100936b9aa11