### PR TITLE
[codex] Add team member verification page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import TerminationGuard from "./components/TerminationGuard";
 import MarketsInfo from "./pages/MarketsInfo";
 import Stats from "./pages/Stats";
 import CommunityPools from "./pages/CommunityPools";
+import TeamMemberVerification from "./pages/TeamMemberVerification";
 
 // Dev-only: lazy-loaded share card preview page (excluded from production builds)
 const DevShareCard = import.meta.env.DEV
@@ -62,6 +63,8 @@ const AppContent = () => {
               <Route path="/community-pools" element={<CommunityPools />} />
               <Route path="/markets-info" element={<MarketsInfo />} />
               <Route path="/stats" element={<Stats />} />
+              <Route path="/team-member-verification" element={<TeamMemberVerification />} />
+              <Route path="/official-verification" element={<TeamMemberVerification />} />
               <Route path="/trade/*" element={<Trade />} />
               <Route path="/portfolio" element={<Portfolio />} />
               <Route path="/referrals" element={<Referrals />} />

--- a/src/assets/icons/navBar-icons/verify.tsx
+++ b/src/assets/icons/navBar-icons/verify.tsx
@@ -1,0 +1,71 @@
+import { FC } from "react";
+
+export const VerifyIcon: FC<{ size?: number }> = ({ size = 16 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M8 1.75L13 3.625V7.3125C13 10.4875 10.8625 13.45 8 14.25C5.1375 13.45 3 10.4875 3 7.3125V3.625L8 1.75Z"
+      stroke="#ECECEC"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M5.75 7.9375L7.25 9.4375L10.5 6.1875"
+      stroke="#ECECEC"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const VerifyActiveIcon: FC<{ size?: number }> = ({ size = 16 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M8 1.75L13 3.625V7.3125C13 10.4875 10.8625 13.45 8 14.25C5.1375 13.45 3 10.4875 3 7.3125V3.625L8 1.75Z"
+      stroke="url(#verify_shield_gradient)"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M5.75 7.9375L7.25 9.4375L10.5 6.1875"
+      stroke="url(#verify_check_gradient)"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <defs>
+      <linearGradient
+        id="verify_shield_gradient"
+        x1="3"
+        y1="8"
+        x2="13"
+        y2="8"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#FFC955" />
+        <stop offset="1" stopColor="#FF7CD5" />
+      </linearGradient>
+      <linearGradient
+        id="verify_check_gradient"
+        x1="5.75"
+        y1="7.8125"
+        x2="10.5"
+        y2="7.8125"
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#FFC955" />
+        <stop offset="1" stopColor="#FF7CD5" />
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/src/components/NavBar/NavLinksSection.tsx
+++ b/src/components/NavBar/NavLinksSection.tsx
@@ -37,6 +37,10 @@ import {
   RocketActiveIcon,
   RocketIcon,
 } from "../../assets/icons/navBar-icons/rocket";
+import {
+  VerifyActiveIcon,
+  VerifyIcon,
+} from "../../assets/icons/navBar-icons/verify";
 
 export interface NavLinkAsset {
   to: string;
@@ -66,6 +70,13 @@ const NavLinksSection: React.FC<NavLinksSectionProps> = ({
       label: "Markets",
       icon: MarketsIcon,
       activeIcon: MarketsActiveIcon,
+      showOnMobile: true,
+    },
+    {
+      to: "/team-member-verification",
+      label: "Verify",
+      icon: VerifyIcon,
+      activeIcon: VerifyActiveIcon,
       showOnMobile: true,
     },
     {

--- a/src/components/NavBar/NavLinksSection.tsx
+++ b/src/components/NavBar/NavLinksSection.tsx
@@ -73,13 +73,6 @@ const NavLinksSection: React.FC<NavLinksSectionProps> = ({
       showOnMobile: true,
     },
     {
-      to: "/team-member-verification",
-      label: "Verify",
-      icon: VerifyIcon,
-      activeIcon: VerifyActiveIcon,
-      showOnMobile: true,
-    },
-    {
       to: `/trade?market=${encodedMarket}`,
       label: "Trade",
       icon: TradeIcon,
@@ -132,6 +125,13 @@ const NavLinksSection: React.FC<NavLinksSectionProps> = ({
           },
         ]
       : []),
+    {
+      to: "/team-member-verification",
+      label: "Verify",
+      icon: VerifyIcon,
+      activeIcon: VerifyActiveIcon,
+      showOnMobile: true,
+    },
     // {
     //   to: "/faucet",
     //   label: "Faucet",

--- a/src/hooks/useTeamMemberVerification.ts
+++ b/src/hooks/useTeamMemberVerification.ts
@@ -35,7 +35,7 @@ export interface TeamMemberVerificationResponse {
   verified: boolean;
   query: {
     value: string;
-    type?: TeamMemberVerificationType;
+    type: TeamMemberVerificationType;
     normalizedValue: string;
   };
   result?: TeamMemberVerificationRecord;
@@ -43,7 +43,7 @@ export interface TeamMemberVerificationResponse {
 
 export interface TeamMemberVerificationRequest {
   value: string;
-  type?: TeamMemberVerificationType;
+  type: TeamMemberVerificationType;
 }
 
 const verifyTeamMember = async (

--- a/src/hooks/useTeamMemberVerification.ts
+++ b/src/hooks/useTeamMemberVerification.ts
@@ -1,0 +1,77 @@
+import { useMutation } from "@tanstack/react-query";
+import { DATA_API_BASE_URL } from "../constants/applications";
+
+export const TEAM_MEMBER_VERIFICATION_TYPES = [
+  "email",
+  "telegram",
+  "x",
+  "discord",
+  "linkedin",
+  "url",
+  "wallet",
+  "phone",
+  "other",
+] as const;
+
+export type TeamMemberVerificationType =
+  (typeof TEAM_MEMBER_VERIFICATION_TYPES)[number];
+
+export interface TeamMemberVerificationRecord {
+  _id: string;
+  type: TeamMemberVerificationType;
+  value: string;
+  normalizedValue: string;
+  memberName: string;
+  role?: string;
+  profileUrl?: string;
+  contactLabel?: string;
+  notes?: string;
+  enabled: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface TeamMemberVerificationResponse {
+  verified: boolean;
+  query: {
+    value: string;
+    type?: TeamMemberVerificationType;
+    normalizedValue: string;
+  };
+  result?: TeamMemberVerificationRecord;
+}
+
+export interface TeamMemberVerificationRequest {
+  value: string;
+  type?: TeamMemberVerificationType;
+}
+
+const verifyTeamMember = async (
+  payload: TeamMemberVerificationRequest
+): Promise<TeamMemberVerificationResponse> => {
+  const response = await fetch(
+    `${DATA_API_BASE_URL}/team-member-verifications/verify`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      message || `Verification request failed: ${response.status}`
+    );
+  }
+
+  return response.json() as Promise<TeamMemberVerificationResponse>;
+};
+
+export const useTeamMemberVerification = () => {
+  return useMutation({
+    mutationFn: verifyTeamMember,
+  });
+};

--- a/src/pages/TeamMemberVerification/index.tsx
+++ b/src/pages/TeamMemberVerification/index.tsx
@@ -9,8 +9,8 @@ import {
   ShieldQuestion,
 } from "lucide-react";
 import {
-  TeamMemberVerificationType,
   useTeamMemberVerification,
+  TeamMemberVerificationType,
 } from "../../hooks/useTeamMemberVerification";
 import theme from "../../theme";
 import {
@@ -44,19 +44,13 @@ import {
   VerificationGrid,
 } from "./team-member-verification-styles";
 
-type VerificationSelectValue = TeamMemberVerificationType | "auto";
 type ResultState = "idle" | "verified" | "unverified";
 
 const VERIFICATION_TYPES: Array<{
-  value: VerificationSelectValue;
+  value: TeamMemberVerificationType;
   label: string;
   placeholder: string;
 }> = [
-  {
-    value: "auto",
-    label: "Auto detect",
-    placeholder: "URL, email, handle, wallet, or phone",
-  },
   {
     value: "telegram",
     label: "Telegram",
@@ -118,7 +112,7 @@ const TYPE_LABELS: Record<TeamMemberVerificationType, string> = {
 
 const TeamMemberVerification: React.FC = () => {
   const [verificationType, setVerificationType] =
-    useState<VerificationSelectValue>("auto");
+    useState<TeamMemberVerificationType>("telegram");
   const [query, setQuery] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
   const verification = useTeamMemberVerification();
@@ -149,7 +143,7 @@ const TeamMemberVerification: React.FC = () => {
     verification.reset();
     await verification.mutateAsync({
       value: trimmedQuery,
-      type: verificationType === "auto" ? undefined : verificationType,
+      type: verificationType,
     });
   };
 
@@ -275,7 +269,7 @@ const TeamMemberVerification: React.FC = () => {
             <TypeSelect
               value={verificationType}
               onChange={(event) =>
-                setVerificationType(event.target.value as VerificationSelectValue)
+                setVerificationType(event.target.value as TeamMemberVerificationType)
               }
               aria-label="Verification type"
             >

--- a/src/pages/TeamMemberVerification/index.tsx
+++ b/src/pages/TeamMemberVerification/index.tsx
@@ -1,0 +1,347 @@
+import { FormEvent, useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  Info,
+  Search,
+  ShieldCheck,
+  ShieldQuestion,
+} from "lucide-react";
+import {
+  TeamMemberVerificationType,
+  useTeamMemberVerification,
+} from "../../hooks/useTeamMemberVerification";
+import theme from "../../theme";
+import {
+  DetailLabel,
+  DetailList,
+  DetailRow,
+  DetailValue,
+  Eyebrow,
+  HeroSection,
+  Notice,
+  NoticeStack,
+  PageShell,
+  PanelCopy,
+  PanelHeader,
+  PanelTitle,
+  ProfileLink,
+  QueryInput,
+  ResultCopy,
+  ResultPanel,
+  ResultStatus,
+  ResultTitle,
+  SafetyCopy,
+  SafetySection,
+  SafetyTitle,
+  SearchButton,
+  SearchRow,
+  Subtitle,
+  Title,
+  ToolPanel,
+  TypeSelect,
+  VerificationGrid,
+} from "./team-member-verification-styles";
+
+type VerificationSelectValue = TeamMemberVerificationType | "auto";
+type ResultState = "idle" | "verified" | "unverified";
+
+const VERIFICATION_TYPES: Array<{
+  value: VerificationSelectValue;
+  label: string;
+  placeholder: string;
+}> = [
+  {
+    value: "auto",
+    label: "Auto detect",
+    placeholder: "URL, email, handle, wallet, or phone",
+  },
+  {
+    value: "telegram",
+    label: "Telegram",
+    placeholder: "@overlay_member or t.me/overlay_member",
+  },
+  {
+    value: "x",
+    label: "X / Twitter",
+    placeholder: "@overlay_member or x.com/overlay_member",
+  },
+  {
+    value: "email",
+    label: "Email",
+    placeholder: "name@overlay.market",
+  },
+  {
+    value: "discord",
+    label: "Discord",
+    placeholder: "overlay_member",
+  },
+  {
+    value: "linkedin",
+    label: "LinkedIn",
+    placeholder: "linkedin.com/in/overlay-member",
+  },
+  {
+    value: "url",
+    label: "URL",
+    placeholder: "https://overlay.market/team",
+  },
+  {
+    value: "wallet",
+    label: "Wallet",
+    placeholder: "0x...",
+  },
+  {
+    value: "phone",
+    label: "Phone",
+    placeholder: "+1 555 010 1234",
+  },
+  {
+    value: "other",
+    label: "Other",
+    placeholder: "Official identifier",
+  },
+];
+
+const TYPE_LABELS: Record<TeamMemberVerificationType, string> = {
+  email: "Email",
+  telegram: "Telegram",
+  x: "X / Twitter",
+  discord: "Discord",
+  linkedin: "LinkedIn",
+  url: "URL",
+  wallet: "Wallet",
+  phone: "Phone",
+  other: "Other",
+};
+
+const TeamMemberVerification: React.FC = () => {
+  const [verificationType, setVerificationType] =
+    useState<VerificationSelectValue>("auto");
+  const [query, setQuery] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const verification = useTeamMemberVerification();
+
+  const selectedType = useMemo(
+    () =>
+      VERIFICATION_TYPES.find((type) => type.value === verificationType) ??
+      VERIFICATION_TYPES[0],
+    [verificationType]
+  );
+
+  const resultState: ResultState = verification.data
+    ? verification.data.verified
+      ? "verified"
+      : "unverified"
+    : "idle";
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      setLocalError("Enter an identity to verify.");
+      return;
+    }
+
+    setLocalError(null);
+    verification.reset();
+    await verification.mutateAsync({
+      value: trimmedQuery,
+      type: verificationType === "auto" ? undefined : verificationType,
+    });
+  };
+
+  const renderResult = () => {
+    const record = verification.data?.result;
+
+    if (verification.isPending) {
+      return (
+        <>
+          <ResultStatus $state="idle">
+            <Search size={14} />
+            Checking
+          </ResultStatus>
+          <ResultTitle>Verification in progress</ResultTitle>
+          <ResultCopy>Matching this identity against the Overlay verification registry.</ResultCopy>
+        </>
+      );
+    }
+
+    if (record) {
+      return (
+        <>
+          <ResultStatus $state="verified">
+            <CheckCircle2 size={14} />
+            Verified
+          </ResultStatus>
+          <ResultTitle>Official Overlay team member</ResultTitle>
+          <ResultCopy>
+            This identity is listed in the Overlay team verification registry.
+          </ResultCopy>
+          <DetailList>
+            <DetailRow>
+              <DetailLabel>Team member</DetailLabel>
+              <DetailValue>{record.memberName}</DetailValue>
+            </DetailRow>
+            {record.role && (
+              <DetailRow>
+                <DetailLabel>Role</DetailLabel>
+                <DetailValue>{record.role}</DetailValue>
+              </DetailRow>
+            )}
+            <DetailRow>
+              <DetailLabel>{record.contactLabel || TYPE_LABELS[record.type]}</DetailLabel>
+              <DetailValue>{record.value}</DetailValue>
+            </DetailRow>
+            {record.notes && (
+              <DetailRow>
+                <DetailLabel>Note</DetailLabel>
+                <DetailValue>{record.notes}</DetailValue>
+              </DetailRow>
+            )}
+          </DetailList>
+          {record.profileUrl && (
+            <ProfileLink href={record.profileUrl} target="_blank" rel="noopener noreferrer">
+              View profile <ExternalLink size={14} />
+            </ProfileLink>
+          )}
+        </>
+      );
+    }
+
+    if (verification.data && !verification.data.verified) {
+      return (
+        <>
+          <ResultStatus $state="unverified">
+            <AlertTriangle size={14} />
+            Not verified
+          </ResultStatus>
+          <ResultTitle>No official match</ResultTitle>
+          <ResultCopy>
+            This identity is not currently listed as an official Overlay team
+            member contact. Treat requests from it as unverified.
+          </ResultCopy>
+          <DetailList>
+            <DetailRow>
+              <DetailLabel>Submitted identity</DetailLabel>
+              <DetailValue>{verification.data.query.value}</DetailValue>
+            </DetailRow>
+          </DetailList>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <ResultStatus $state="idle">
+          <ShieldQuestion size={14} />
+          Awaiting search
+        </ResultStatus>
+        <ResultTitle>Verify before you trust</ResultTitle>
+        <ResultCopy>
+          Search the registry for an Overlay team member identity before
+          responding to private outreach.
+        </ResultCopy>
+      </>
+    );
+  };
+
+  return (
+    <PageShell>
+      <HeroSection>
+        <Eyebrow>Overlay Verify</Eyebrow>
+        <Title>Team member verification</Title>
+        <Subtitle>
+          Check whether a URL, email address, wallet, phone number, Telegram,
+          Discord, X, or LinkedIn account is officially associated with an
+          Overlay team member.
+        </Subtitle>
+      </HeroSection>
+
+      <VerificationGrid>
+        <ToolPanel onSubmit={handleSubmit}>
+          <PanelHeader>
+            <PanelTitle>Identity lookup</PanelTitle>
+            <PanelCopy>
+              Overlay Verify only assists identity verification. Verification
+              does not grant authorization for any actions or listings. Overlay
+              will never request funds or tokens via private communications.
+            </PanelCopy>
+          </PanelHeader>
+
+          <SearchRow>
+            <TypeSelect
+              value={verificationType}
+              onChange={(event) =>
+                setVerificationType(event.target.value as VerificationSelectValue)
+              }
+              aria-label="Verification type"
+            >
+              {VERIFICATION_TYPES.map((type) => (
+                <option key={type.value} value={type.value}>
+                  {type.label}
+                </option>
+              ))}
+            </TypeSelect>
+            <QueryInput
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                if (localError) setLocalError(null);
+              }}
+              placeholder={selectedType.placeholder}
+              aria-label="Identity to verify"
+            />
+            <SearchButton
+              type="submit"
+              disabled={verification.isPending}
+            >
+              {verification.isPending ? (
+                <ShieldCheck size={17} />
+              ) : (
+                <Search size={17} />
+              )}
+              Search
+            </SearchButton>
+          </SearchRow>
+
+          <NoticeStack>
+            {localError && (
+              <Notice style={{ color: theme.semantic.negative }}>
+                <AlertTriangle size={16} />
+                {localError}
+              </Notice>
+            )}
+            {verification.isError && (
+              <Notice style={{ color: theme.semantic.negative }}>
+                <AlertTriangle size={16} />
+                Unable to complete verification. Try again shortly.
+              </Notice>
+            )}
+            <Notice>
+              <Info size={16} />
+              Overlay Verify only assists identity verification. Verification
+              does not grant authorization for any actions or listings. Overlay
+              will never request funds or tokens via private communications.
+            </Notice>
+          </NoticeStack>
+        </ToolPanel>
+
+        <ResultPanel $state={resultState}>{renderResult()}</ResultPanel>
+      </VerificationGrid>
+
+      <SafetySection>
+        <SafetyTitle>Stay Safe!</SafetyTitle>
+        <SafetyCopy>
+          Always verify the exact identity before responding to outreach. If a
+          message requests funds, tokens, private keys, seed phrases, or wallet
+          access, treat it as unverified and do not proceed.
+        </SafetyCopy>
+      </SafetySection>
+    </PageShell>
+  );
+};
+
+export default TeamMemberVerification;

--- a/src/pages/TeamMemberVerification/team-member-verification-styles.ts
+++ b/src/pages/TeamMemberVerification/team-member-verification-styles.ts
@@ -1,0 +1,340 @@
+import styled, { css } from "styled-components";
+import theme from "../../theme";
+
+export const PageShell = styled.main`
+  display: grid;
+  gap: 14px;
+  width: 100%;
+  min-height: calc(100vh - ${theme.headerSize.mobileHeight});
+  padding: 14px 14px calc(96px + env(safe-area-inset-bottom));
+  background: linear-gradient(180deg, #070809 0%, ${theme.semantic.bg} 48%);
+  color: ${theme.semantic.textPrimary};
+
+  @media (min-width: ${theme.breakpoints.sm}) {
+    min-height: calc(100vh - ${theme.headerSize.height});
+    padding: 20px 24px 44px;
+  }
+
+  @media (min-width: ${theme.breakpoints.lg}) {
+    padding: 24px 36px 52px;
+  }
+`;
+
+export const HeroSection = styled.section`
+  display: grid;
+  gap: 10px;
+  max-width: 960px;
+`;
+
+export const Eyebrow = styled.div`
+  color: ${theme.semantic.accent};
+  font-size: 12px;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+`;
+
+export const Title = styled.h1`
+  max-width: 800px;
+  margin: 0;
+  color: ${theme.semantic.textPrimary};
+  font-size: 36px;
+  font-weight: 900;
+  line-height: 0.98;
+  letter-spacing: 0;
+
+  @media (min-width: ${theme.breakpoints.sm}) {
+    font-size: 48px;
+  }
+`;
+
+export const Subtitle = styled.p`
+  max-width: 720px;
+  margin: 0;
+  color: ${theme.semantic.textSecondary};
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.45;
+`;
+
+export const VerificationGrid = styled.section`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+  align-items: stretch;
+
+  @media (min-width: ${theme.breakpoints.lg}) {
+    grid-template-columns: minmax(0, 1.08fr) minmax(340px, 0.92fr);
+  }
+`;
+
+export const ToolPanel = styled.form`
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid ${theme.semantic.border};
+  border-radius: ${theme.radius.md};
+  background:
+    radial-gradient(circle at top right, rgba(243, 169, 27, 0.11), transparent 34%),
+    ${theme.semantic.panel};
+  box-shadow: ${theme.shadow.panel};
+
+  @media (min-width: ${theme.breakpoints.sm}) {
+    padding: 22px;
+  }
+`;
+
+export const PanelHeader = styled.div`
+  display: grid;
+  gap: 4px;
+`;
+
+export const PanelTitle = styled.h2`
+  margin: 0;
+  color: ${theme.semantic.textPrimary};
+  font-size: 20px;
+  font-weight: 900;
+  line-height: 1.15;
+`;
+
+export const PanelCopy = styled.p`
+  max-width: 620px;
+  margin: 0;
+  color: ${theme.semantic.textMuted};
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.45;
+`;
+
+export const SearchRow = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 10px;
+
+  @media (min-width: ${theme.breakpoints.md}) {
+    grid-template-columns: minmax(156px, 0.35fr) minmax(0, 1fr) auto;
+  }
+`;
+
+const fieldStyles = css`
+  width: 100%;
+  min-width: 0;
+  height: 48px;
+  border: 1px solid ${theme.semantic.border};
+  border-radius: ${theme.radius.md};
+  background: ${theme.semantic.field};
+  color: ${theme.semantic.textPrimary};
+  font-size: 14px;
+  font-weight: 700;
+
+  &:focus {
+    border-color: ${theme.semantic.focus};
+    outline: none;
+    box-shadow: ${theme.shadow.focus};
+  }
+`;
+
+export const TypeSelect = styled.select`
+  ${fieldStyles}
+  padding: 0 38px 0 14px;
+  cursor: pointer;
+`;
+
+export const QueryInput = styled.input`
+  ${fieldStyles}
+  padding: 0 14px;
+
+  &::placeholder {
+    color: ${theme.semantic.textMuted};
+  }
+`;
+
+export const SearchButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-width: 132px;
+  height: 48px;
+  border: 0;
+  border-radius: ${theme.radius.md};
+  background: ${theme.gradient.accent};
+  color: #111214;
+  font-size: 14px;
+  font-weight: 900;
+  cursor: pointer;
+  transition: transform 0.14s ease, filter 0.14s ease;
+
+  &:hover:not(:disabled) {
+    filter: brightness(1.06);
+    transform: translateY(-1px);
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    filter: grayscale(0.42);
+    opacity: 0.72;
+  }
+`;
+
+export const NoticeStack = styled.div`
+  display: grid;
+  gap: 8px;
+`;
+
+export const Notice = styled.div`
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px;
+  border: 1px solid ${theme.semantic.borderMuted};
+  border-radius: ${theme.radius.md};
+  background: rgba(24, 26, 31, 0.7);
+  color: ${theme.semantic.textSecondary};
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.42;
+`;
+
+export const ResultPanel = styled.aside<{ $state: "idle" | "verified" | "unverified" }>`
+  display: grid;
+  align-content: start;
+  gap: 16px;
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid
+    ${({ $state }) => {
+      if ($state === "verified") return theme.semantic.positive;
+      if ($state === "unverified") return theme.semantic.negative;
+      return theme.semantic.border;
+    }};
+  border-radius: ${theme.radius.md};
+  background:
+    ${({ $state }) => {
+      if ($state === "verified") {
+        return "linear-gradient(180deg, rgba(40, 209, 154, 0.12), rgba(16, 17, 20, 0.96))";
+      }
+      if ($state === "unverified") {
+        return "linear-gradient(180deg, rgba(240, 68, 94, 0.12), rgba(16, 17, 20, 0.96))";
+      }
+      return theme.semantic.panel;
+    }};
+  box-shadow: ${theme.shadow.panel};
+
+  @media (min-width: ${theme.breakpoints.sm}) {
+    padding: 22px;
+  }
+`;
+
+export const ResultStatus = styled.div<{ $state: "idle" | "verified" | "unverified" }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: ${({ $state }) => {
+    if ($state === "verified") return theme.semantic.positiveSoft;
+    if ($state === "unverified") return theme.semantic.negativeSoft;
+    return theme.semantic.field;
+  }};
+  color: ${({ $state }) => {
+    if ($state === "verified") return theme.semantic.positive;
+    if ($state === "unverified") return theme.semantic.negative;
+    return theme.semantic.textSecondary;
+  }};
+  font-size: 12px;
+  font-weight: 900;
+`;
+
+export const ResultTitle = styled.h2`
+  margin: 0;
+  color: ${theme.semantic.textPrimary};
+  font-size: 24px;
+  font-weight: 900;
+  line-height: 1.1;
+`;
+
+export const ResultCopy = styled.p`
+  margin: 0;
+  color: ${theme.semantic.textSecondary};
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.5;
+`;
+
+export const DetailList = styled.dl`
+  display: grid;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+`;
+
+export const DetailRow = styled.div`
+  display: grid;
+  gap: 4px;
+`;
+
+export const DetailLabel = styled.dt`
+  color: ${theme.semantic.textMuted};
+  font-size: 11px;
+  font-weight: 900;
+  text-transform: uppercase;
+`;
+
+export const DetailValue = styled.dd`
+  min-width: 0;
+  margin: 0;
+  color: ${theme.semantic.textPrimary};
+  font-size: 14px;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+`;
+
+export const ProfileLink = styled.a`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  color: ${theme.semantic.accentHover};
+  font-size: 13px;
+  font-weight: 900;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const SafetySection = styled.section`
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 16px 18px;
+  border: 1px solid ${theme.semantic.borderMuted};
+  border-radius: ${theme.radius.md};
+  background: ${theme.semantic.bgElevated};
+
+  @media (min-width: ${theme.breakpoints.sm}) {
+    padding: 18px 20px;
+  }
+`;
+
+export const SafetyTitle = styled.h2`
+  margin: 0;
+  color: ${theme.semantic.textPrimary};
+  font-size: 18px;
+  font-weight: 900;
+  line-height: 1.2;
+`;
+
+export const SafetyCopy = styled.p`
+  max-width: 960px;
+  margin: 0;
+  color: ${theme.semantic.textSecondary};
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.45;
+`;


### PR DESCRIPTION
## Summary

Adds an Overlay team member verification page inspired by official-verification flows, with routes for `/team-member-verification` and `/official-verification`.

## Changes

- Adds a verification page with type selection, identity lookup input, verified and unverified result states, and a professional safety section.
- Adds a React Query mutation hook for the data API verification endpoint.
- Adds a Verify navigation item and icon.

## Validation

- `pnpm lint`
- `pnpm build`

Note: `main` was reverted in commit `1fc78d3`; this branch reapplies the verification page as a reviewable PR.