### PR TITLE
Polish navigation and button typography (Inter, weights, tracking)

### DIFF
--- a/src/components/Button/gradient-button-styles.ts
+++ b/src/components/Button/gradient-button-styles.ts
@@ -30,7 +30,10 @@ export const GradientOutlineBtnWrapper = styled(Button)<{
     : `linear-gradient(${theme.semantic.panel}, ${theme.semantic.panel}) padding-box,
       ${theme.gradient.accent} border-box`)};
   color: ${theme.semantic.accent};
-  font-weight: 700;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.012em;
   line-height: 1;
   white-space: nowrap;
   transition: background 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease;
@@ -48,6 +51,9 @@ export const GradientOutlineBtnWrapper = styled(Button)<{
 export const ButtonTitle = styled.div<{ color?: string, disabled?: boolean }>`
   line-height: 1;
   white-space: nowrap;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  text-transform: none;
   background: ${({ disabled }) => (disabled 
     ? `linear-gradient(90deg, ${theme.semantic.textMuted} 0%, ${theme.semantic.textSecondary} 100%)` 
     : theme.gradient.accentText)};
@@ -71,7 +77,10 @@ export const GradientSolidBtnWrapper = styled(Button)<{
   height: ${({ height }) => (height ? height : "auto")};
   background: ${theme.gradient.accent};
   color: ${theme.color.black};
-  font-weight: 700;
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: 0.012em;
   line-height: 1;
   white-space: nowrap;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};

--- a/src/components/NavBar/styled-nav-link-styles.ts
+++ b/src/components/NavBar/styled-nav-link-styles.ts
@@ -31,8 +31,10 @@ export const StyledBox = styled(Box)`
 
 export const StyledLink = styled(NavLink)`
   color: ${theme.semantic.textMuted};
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-size: 12px;
-  font-weight: 400;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   text-decoration: none;
 
   @media (min-width: ${theme.breakpoints.sm}) {
@@ -40,7 +42,8 @@ export const StyledLink = styled(NavLink)`
     align-items: center;
     height: ${theme.headerSize.height};
     font-size: 14px;
-    font-weight: 500;
+    font-weight: 550;
+    letter-spacing: 0.012em;
     text-decoration: none;
   }
   &.active {
@@ -55,7 +58,8 @@ export const StyledLink = styled(NavLink)`
 `;
 
 export const ActiveLabel = styled(Box)`
-  font-weight: 700;
+  font-weight: 600;
+  letter-spacing: 0.014em;
   color: ${theme.semantic.accent};
 
   @media (min-width: ${theme.breakpoints.sm}) {
@@ -65,8 +69,10 @@ export const ActiveLabel = styled(Box)`
 
 export const StyledLinkBurgerMode = styled(NavLink)`
   color: ${theme.color.grey2};
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-size: 14px;
-  font-weight: 400;
+  font-weight: 500;
+  letter-spacing: 0.01em;
   text-decoration: none;
 
   &:focus-visible {


### PR DESCRIPTION
### Motivation
- Improve landing experience by tightening type rhythm and visual hierarchy for navigation and CTA buttons to align with a premium crypto/finance tone.
- Standardize on the `Inter` font family and adjust weights/letter-spacing so nav items and buttons read more intentional and cohesive across desktop and mobile.

### Description
- Update `src/components/NavBar/styled-nav-link-styles.ts` to use `Inter` for `StyledLink` and `StyledLinkBurgerMode`, raise baseline weights, and add subtle `letter-spacing` for desktop and burger variants.
- Adjust the active label in the nav by reducing extreme weight and adding tracking in `ActiveLabel` to make active states feel refined and not overly heavy.
- Update `src/components/Button/gradient-button-styles.ts` to apply `Inter` to `GradientOutlineBtnWrapper` and `GradientSolidBtnWrapper`, tune `font-size`, `font-weight`, and `letter-spacing`, and make `ButtonTitle` inherit weight/spacing and avoid forced transforms so gradient text labels follow the new typography.
- These changes are a focused follow-up to refine the landing menu/button typography on top of the earlier landing page refinements.

### Testing
- Ran a production build with `pnpm build` and the build completed successfully.
- No additional automated tests were modified or required for these style updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b6ca8854832eb596e0acda60f73c)