### PR TITLE
[Overlay] Add RPL/USD market to frontend MARKETSORDER

### DIFF
--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -247,6 +247,7 @@ export const MARKETSORDER = [
   "Knives%20-%20CS2%20Skins",
   "Frogs%20vs%20Dogs%20-%20Meme%20War",
   "Knives%20vs%20Rifles%20-%20CS2%20Skins",
+  "RPL%2FUSD",
 ];
 
 export const EXCLUDEDMARKETS = ["ETH%20Dominance", "Hikaru%20Nakamura"];


### PR DESCRIPTION
Auto-generated by `overlay frontend RPL/USD`.

- Pair: RPL/USD
- Market address: 0xE12c720A458ce90873B45C30A0Dd67ab28fF8F9a
- Category: Altcoins
- Chain: BSC Mainnet (chain_id=56)
- Aggregator: 0xFB0c25812d5326976Dc7598eB20E39447d209E9f
