### PR TITLE
[Overlay] Add INV/USD market to frontend MARKETSORDER

### DIFF
--- a/src/constants/markets.ts
+++ b/src/constants/markets.ts
@@ -247,6 +247,7 @@ export const MARKETSORDER = [
   "Knives%20-%20CS2%20Skins",
   "Frogs%20vs%20Dogs%20-%20Meme%20War",
   "Knives%20vs%20Rifles%20-%20CS2%20Skins",
+  "INV%2FUSD",
 ];
 
 export const EXCLUDEDMARKETS = ["ETH%20Dominance", "Hikaru%20Nakamura"];


### PR DESCRIPTION
Auto-generated by `overlay frontend INV/USD`.

- Pair: INV/USD
- Market address: 0x50D02D5AcAc3F1a01c12F9eF9Cdd8403F6eF5167
- Category: Altcoins
- Chain: BSC Mainnet (chain_id=56)
- Aggregator: 0xbc3Ab2D22D29b7Fe32486282511F220114DCccC1
