### PR TITLE
Hide Community Pools and Funded Trader pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ import Referrals from "./pages/Referrals";
 import Leaderboard from "./pages/Leaderboard";
 import { LiFiProvider } from "./providers/LiFiProvider";
 import Airdrops from "./pages/Airdrops";
-import FundedTrader from "./pages/FundedTrader";
 import ExchangeLiFi from "./pages/ExchangeLiFi";
 import AnalyticsListener from "./analytics/AnalyticsListener";
 import WalletTracker from "./analytics/WalletTracker";
@@ -26,7 +25,6 @@ import useAccount from "./hooks/useAccount";
 import TerminationGuard from "./components/TerminationGuard";
 import MarketsInfo from "./pages/MarketsInfo";
 import Stats from "./pages/Stats";
-import CommunityPools from "./pages/CommunityPools";
 import TeamMemberVerification from "./pages/TeamMemberVerification";
 
 // Dev-only: lazy-loaded share card preview page (excluded from production builds)
@@ -60,7 +58,6 @@ const AppContent = () => {
             <Routes>
               <Route path="/" element={<Navigate to="/markets" />} />
               <Route path="/markets" element={<Markets />} />
-              <Route path="/community-pools" element={<CommunityPools />} />
               <Route path="/markets-info" element={<MarketsInfo />} />
               <Route path="/stats" element={<Stats />} />
               <Route path="/team-member-verification" element={<TeamMemberVerification />} />
@@ -74,7 +71,6 @@ const AppContent = () => {
                 element={<Leaderboard />}
               />
               <Route path="/airdrops" element={<Airdrops />} />
-              <Route path="/funded-trader" element={<FundedTrader />} />
               <Route path="/exchange/*" element={exchangeElement} />
               {DevShareCard && (
                 <Route path="/dev/share-card" element={<Suspense fallback={null}><DevShareCard /></Suspense>} />

--- a/src/components/NavBar/NavLinksSection.tsx
+++ b/src/components/NavBar/NavLinksSection.tsx
@@ -29,15 +29,6 @@ import {
   MarketsIcon,
 } from "../../assets/icons/navBar-icons/markets";
 import {
-  FundedTraderIcon,
-  FundedTraderActiveIcon,
-} from "../../assets/icons/navBar-icons/funded-trader";
-import { useAvatarTrading } from "../../hooks/useAvatarTrading";
-import {
-  RocketActiveIcon,
-  RocketIcon,
-} from "../../assets/icons/navBar-icons/rocket";
-import {
   VerifyActiveIcon,
   VerifyIcon,
 } from "../../assets/icons/navBar-icons/verify";
@@ -58,7 +49,6 @@ const NavLinksSection: React.FC<NavLinksSectionProps> = ({
   mode = NAVBAR_MODE.DEFAULT,
 }) => {
   const { currentMarket } = useCurrentMarketState();
-  const { isAvatarTradingActive } = useAvatarTrading();
 
   const activeMarket = currentMarket?.marketName ?? DEFAULT_MARKET;
   const encodedMarket = encodeURIComponent(activeMarket);
@@ -77,16 +67,6 @@ const NavLinksSection: React.FC<NavLinksSectionProps> = ({
       label: "Trade",
       icon: TradeIcon,
       activeIcon: TradeActiveIcon,
-      showOnMobile: true,
-    },
-    {
-      to: "/community-pools",
-      label:
-        isMobile && mode === NAVBAR_MODE.DEFAULT
-          ? "Pools"
-          : "Community Pools",
-      icon: RocketIcon,
-      activeIcon: RocketActiveIcon,
       showOnMobile: true,
     },
     {
@@ -111,20 +91,6 @@ const NavLinksSection: React.FC<NavLinksSectionProps> = ({
       activeIcon: TrophyActiveIcon,
       showOnMobile: true,
     },
-    ...(!isAvatarTradingActive
-      ? [
-          {
-            to: "/funded-trader",
-            label:
-              isMobile && mode === NAVBAR_MODE.DEFAULT
-                ? "Funded"
-                : "Funded Trader",
-            icon: FundedTraderIcon,
-            activeIcon: FundedTraderActiveIcon,
-            showOnMobile: true,
-          },
-        ]
-      : []),
     {
       to: "/team-member-verification",
       label: "Verify",


### PR DESCRIPTION
## Summary
- Removes the `/community-pools` and `/funded-trader` routes from `App.tsx` — the wildcard route already redirects unmatched paths to `/markets`, so direct navigation to either URL now redirects there too.
- Removes the "Community Pools" and "Funded Trader" entries (and their now-unused icon imports / `useAvatarTrading` gating) from the nav bar in `NavLinksSection.tsx`.
- Page components (`src/pages/CommunityPools`, `src/pages/FundedTrader`) and their supporting hooks/constants are left in place, unreferenced — only routing and nav visibility change. The Funded Trader stats widget on the Portfolio Overview page is unrelated and untouched.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/App.tsx src/components/NavBar/NavLinksSection.tsx` — clean
- [x] `npx vite build` — succeeds
- [ ] Manually verify `/community-pools` and `/funded-trader` redirect to `/markets` and no longer appear in the nav bar (desktop + mobile burger menu) once deployed